### PR TITLE
Add i18n support for button titles and empty states

### DIFF
--- a/src/components/layout/Canvas.tsx
+++ b/src/components/layout/Canvas.tsx
@@ -273,7 +273,7 @@ export default function Canvas() {
             <div className="text-center space-y-4">
               <FileCode className="w-16 h-16 text-muted-foreground mx-auto" />
               <p className="text-muted-foreground">
-                Select a file to start editing
+                {t("editor.selectFile")}
               </p>
             </div>
           </div>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -502,7 +502,7 @@ export default function Header() {
         <button
           onClick={openVariablesWindow}
           className="p-2 hover:bg-accent rounded-md transition-colors"
-          title="Manage Global Variables"
+          title={t("variables.manager")}
         >
           <Layers className="w-4 h-4 text-muted-foreground" />
         </button>
@@ -529,7 +529,7 @@ export default function Header() {
         <button
           onClick={openSettingsWindow}
           className="p-2 hover:bg-accent rounded-md transition-colors"
-          title="Settings"
+          title={t("settings.title")}
         >
           <SettingsIcon className="w-4 h-4 text-muted-foreground" />
         </button>

--- a/src/components/layout/Inspector.tsx
+++ b/src/components/layout/Inspector.tsx
@@ -81,7 +81,7 @@ export default function Inspector() {
         ) : (
           <div className="flex items-center justify-center h-full p-4">
             <p className="text-sm text-muted-foreground text-center">
-              Open a file to view variables and options
+              {t("inspector.selectFile")}
             </p>
           </div>
         )}

--- a/src/components/variables/VariablesManager.tsx
+++ b/src/components/variables/VariablesManager.tsx
@@ -173,6 +173,7 @@ export default function VariablesManager({ onClose, isStandaloneWindow = false }
                     <button
                       onClick={() => setSearchQuery("")}
                       className="absolute right-3 top-1/2 -translate-y-1/2 p-0.5 hover:bg-accent rounded transition-colors"
+                      title={t("actions.clearSearch")}
                     >
                       <X className="w-3.5 h-3.5 text-muted-foreground" />
                     </button>
@@ -181,6 +182,7 @@ export default function VariablesManager({ onClose, isStandaloneWindow = false }
                 <button
                   onClick={handleAddVariable}
                   className="flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-primary rounded-lg hover:bg-primary/90 shadow-sm flex-shrink-0"
+                  title={t("variables.addVariable")}
                 >
                   <Plus className="w-4 h-4" />
                   {t("variables.addVariable")}
@@ -257,6 +259,7 @@ export default function VariablesManager({ onClose, isStandaloneWindow = false }
                     <button
                       onClick={handleAddVariable}
                       className="px-6 py-2.5 text-sm font-medium text-white bg-primary rounded-lg hover:bg-primary/90 shadow-sm"
+                      title={t("variables.addFirstVariable")}
                     >
                       <Plus className="w-4 h-4 inline mr-2" />
                       {t("variables.addFirstVariable")}
@@ -273,6 +276,7 @@ export default function VariablesManager({ onClose, isStandaloneWindow = false }
                     <button
                       onClick={() => setSearchQuery("")}
                       className="mt-3 text-sm text-primary hover:underline"
+                      title={t("actions.clearSearch")}
                     >
                       {t("actions.clearSearch", "清除搜索")}
                     </button>
@@ -307,6 +311,7 @@ export default function VariablesManager({ onClose, isStandaloneWindow = false }
             <button
               onClick={onClose}
               className="px-5 py-2 text-sm font-medium text-foreground bg-secondary rounded-lg hover:bg-secondary/80 transition-colors"
+              title={t("actions.cancel")}
             >
               {t("actions.cancel")}
             </button>
@@ -314,6 +319,7 @@ export default function VariablesManager({ onClose, isStandaloneWindow = false }
               onClick={handleSave}
               disabled={saving}
               className="px-5 py-2 text-sm font-medium text-white bg-primary rounded-lg hover:bg-primary/90 disabled:opacity-50 shadow-sm transition-colors"
+              title={saving ? t("variables.saving") : t("variables.saveVariables")}
             >
               {saving ? t("variables.saving") : t("variables.saveVariables")}
             </button>
@@ -332,6 +338,7 @@ export default function VariablesManager({ onClose, isStandaloneWindow = false }
                 <button
                   onClick={() => setShowHelp(false)}
                   className="p-1 hover:bg-accent rounded transition-colors"
+                  title={t("actions.close")}
                 >
                   <X className="w-4 h-4" />
                 </button>
@@ -419,6 +426,7 @@ export default function VariablesManager({ onClose, isStandaloneWindow = false }
                 <button
                   onClick={() => setShowHelp(false)}
                   className="px-4 py-2 text-sm font-medium text-white bg-primary rounded hover:bg-primary/90"
+                  title={t("variables.helpGotIt")}
                 >
                   {t("variables.helpGotIt")}
                 </button>

--- a/src/i18n/locales/en-US.json
+++ b/src/i18n/locales/en-US.json
@@ -68,7 +68,8 @@
   "inspector": {
     "execution": "Execution",
     "metadata": "Metadata",
-    "history": "History"
+    "history": "History",
+    "selectFile": "Open a file to view variables and options"
   },
   "workspace": {
     "noWorkspace": "No workspace opened",

--- a/src/i18n/locales/zh-Hans.json
+++ b/src/i18n/locales/zh-Hans.json
@@ -68,7 +68,8 @@
   "inspector": {
     "execution": "执行",
     "metadata": "元数据",
-    "history": "历史"
+    "history": "历史",
+    "selectFile": "打开文件以查看变量和选项"
   },
   "workspace": {
     "noWorkspace": "未打开工作区",

--- a/src/i18n/locales/zh-Hant.json
+++ b/src/i18n/locales/zh-Hant.json
@@ -95,7 +95,8 @@
   "inspector": {
     "execution": "執行",
     "metadata": "元資料",
-    "history": "歷史"
+    "history": "歷史",
+    "selectFile": "開啟檔案以查看變數和選項"
   },
   "variables": {
     "manager": "全域變數",


### PR DESCRIPTION
Replaced hardcoded button titles and empty state messages with i18n translation keys in Canvas, Header, Inspector, and VariablesManager components. Updated en-US, zh-Hans, and zh-Hant locale files to include new translation strings for these UI elements.